### PR TITLE
Add responsive personal CV website template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,47 @@
+# Personal CV Website
+
+This repository contains a minimal, responsive CV/portfolio website template built with HTML, TailwindCSS, and vanilla JavaScript. Content is stored in `data.json` so you can update your information without touching the HTML.
+
+## Features
+
+- Clean landing page with name, title, and summary
+- Sections for About, CV/Experience, Projects/Publications, Skills, and Contact
+- Responsive layout with TailwindCSS
+- Optional light/dark mode with preference saved to `localStorage`
+- Easy content updates via `data.json`
+
+## Customization
+
+1. **Update personal data**
+   - Edit `data.json` and replace the example text with your own information.
+2. **Change styling**
+   - TailwindCSS is loaded via CDN in `index.html`. You can adjust classes directly in the HTML if desired.
+3. **Add more sections**
+   - Extend `data.json` and adjust `script.js` if you need additional content areas.
+
+## Local Preview
+
+To view the site locally, serve the files with a simple HTTP server (required for `fetch`):
+
+```bash
+python3 -m http.server 8000
+```
+
+Then open [http://localhost:8000](http://localhost:8000) in your browser.
+
+## Deployment
+
+For a user or organization page named `<username>.github.io`, pushing to the default branch will automatically publish the site via GitHub Pages.
+
+1. Commit your changes.
+2. Push to GitHub:
+
+```bash
+git push origin main
+```
+
+The site will be available at `https://<username>.github.io/` after the push.
+
+## License
+
+Distributed under the MIT License. See `LICENSE` for more information.

--- a/data.json
+++ b/data.json
@@ -1,0 +1,49 @@
+{
+  "name": "Your Name",
+  "title": "Doctoral Researcher in Sustainable Cloud & AI Systems",
+  "summary": "Short professional summary goes here.",
+  "about": "Write a brief bio and explain your current research focus.",
+  "cv": [
+    {
+      "category": "Education",
+      "items": [
+        {
+          "role": "PhD in Computer Science",
+          "org": "University Name",
+          "period": "2022 - Present",
+          "details": "Researching sustainable cloud and AI systems."
+        },
+        {
+          "role": "MSc in Computer Science",
+          "org": "University Name",
+          "period": "2020 - 2022",
+          "details": "Focused on distributed systems." 
+        }
+      ]
+    },
+    {
+      "category": "Experience",
+      "items": [
+        {
+          "role": "Research Assistant",
+          "org": "Institute or Lab",
+          "period": "2019 - 2020",
+          "details": "Worked on cloud optimization projects." 
+        }
+      ]
+    }
+  ],
+  "projects": [
+    {
+      "title": "Project or Publication Title",
+      "description": "Brief description of the project or paper.",
+      "link": "https://github.com/username/repo"
+    }
+  ],
+  "skills": ["Python", "Machine Learning", "Cloud Computing"],
+  "contact": {
+    "email": "you@example.com",
+    "linkedin": "https://linkedin.com/in/username",
+    "github": "https://github.com/username"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,91 +1,40 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="scroll-smooth">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>César Iván Olvera Espinosa</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-鷓੍ਹZHleO1lzw5X3YTfCsQvGfQHvCeCIlLiQvUD4r9FPq1z77zVCTUhzRMlCXNwPL0" crossorigin="anonymous">
-  <link rel="stylesheet" href="style.css">
+  <title>Personal CV</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css">
+  <script defer src="script.js"></script>
 </head>
-<body>
-  <header class="container py-3">
-    <div class="d-flex flex-column align-items-center">
-      <h1><span><b>César</b> Iván Olvera Espinosa</span></h1>
-      <p class="tagline">MSc. in Computer, Communications and Information Sciences</p>
-    </div>
+<body class="bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100 transition-colors duration-300">
+  <header id="landing" class="min-h-screen flex flex-col items-center justify-center text-center px-4">
+    <h1 id="name" class="text-4xl md:text-6xl font-bold mb-4"></h1>
+    <h2 id="title" class="text-xl md:text-2xl mb-4"></h2>
+    <p id="summary" class="max-w-xl"></p>
+    <button id="themeToggle" class="mt-6 border px-4 py-2 rounded">Toggle Theme</button>
   </header>
-
-  <nav class="container py-2">
-    <ul class="nav nav-pills">
-      <li class="nav-item"><a href="#about" class="nav-link">About Me</a></li>
-      <li class="nav-item"><a href="#experience" class="nav-link">Education</a></li>
-      <li class="nav-item"><a href="#skills" class="nav-link">experience-list/a></li>
-      <li class="nav-item"><a href="#education" class="nav-link">Skills</a></li>
-      <li class="nav-item"><a href="#contact" class="nav-link">Contact</a></li>
-    </ul>
-  </nav>
-
-  <main class="container py-4">
-    <section id="about" class="content">
-      <h2>About Me</h2>
-      <p>[Write a concise and captivating bio highlighting your strengths, experience, and career goals]</p>
-      <button class="btn btn-primary expand">Read More</button>
-      <div class="hidden-content">
-        <p>[More details about yourself and your journey]</p>
-      </div>
+  <main class="px-4 md:px-8 space-y-20 pb-20">
+    <section id="about">
+      <h3 class="text-2xl font-semibold mb-4">About Me</h3>
+      <p id="aboutContent" class="max-w-3xl"></p>
     </section>
-
-    <section id="experience" class="content">
-      <h2>Experience</h2>
-      <ul class="list-group experience-list">
-        <li class="list-group-item">
-          <h3>[Job Title 1]</h3>
-          <h4>[Company Name] - [Dates of Employment]</h4>
-          <ul>
-            <li>[Key Responsibility 1]</li>
-            <li>[Key Achievement 1]</li>
-            <li>[Key Responsibility 2]</li>
-            <li>[Key Achievement 2]</li>
-          </ul>
-        </li>
-        <li class="list-group-item">
-          <h3>[Job Title 2]</h3>
-          <h4>[Company Name] - [Dates of Employment]</h4>
-          <ul>
-          </ul>
-        </li>
-      </ul>
+    <section id="cv">
+      <h3 class="text-2xl font-semibold mb-4">CV / Experience</h3>
+      <div id="cvList" class="space-y-6"></div>
     </section>
-
-    <section id="skills" class="content">
-      <h2>Skills</h2>
-      <div class="skills-container row">
-        <div class="skill col-md-6">
-          <h3>[Skill 1]</h3>
-          <div class="progress-bar" data-progress="[Progress Percentage]"></div>
-        </div>
-        <div class="skill col-md-6">
-          <h3>[Skill 2]</h3>
-          <div class="progress-bar" data-progress="[Progress Percentage]"></div>
-        </div>
-      </div>
+    <section id="projects">
+      <h3 class="text-2xl font-semibold mb-4">Projects / Publications</h3>
+      <div id="projectsList" class="space-y-4"></div>
     </section>
-
-    <section id="education" class="content">
-      <h2>Education & Certifications</h2>
-      <ul class="list-group education-list">
-        <li class="list-group-item">
-          <h3>[Degree Name]</h3>
-          <h4>[Institution Name] - [Years of Attendance]</h4>
-        </li>
-        <li class="list-group-item">
-          <h3>[Certification Name]</h3>
-          <h4>[Issuing Institution] - [Year Obtained]</h4>
-        </li>
-      </ul>
+    <section id="skills">
+      <h3 class="text-2xl font-semibold mb-4">Skills</h3>
+      <ul id="skillsList" class="grid grid-cols-2 md:grid-cols-3 gap-2 max-w-3xl"></ul>
     </section>
-
-    <section id="contact" class="content">
-      <h2>Contact</h2>
-      <ul class="contact-info list-group">
-        <li
+    <section id="contact">
+      <h3 class="text-2xl font-semibold mb-4">Contact</h3>
+      <ul id="contactList" class="space-y-2"></ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,74 @@
+async function loadContent() {
+  const res = await fetch('data.json');
+  const data = await res.json();
+
+  document.title = `${data.name} - ${data.title}`;
+  document.getElementById('name').textContent = data.name;
+  document.getElementById('title').textContent = data.title;
+  document.getElementById('summary').textContent = data.summary;
+  document.getElementById('aboutContent').textContent = data.about;
+
+  const cvList = document.getElementById('cvList');
+  data.cv.forEach(section => {
+    const sectionDiv = document.createElement('div');
+    const heading = document.createElement('h4');
+    heading.className = 'text-xl font-medium';
+    heading.textContent = section.category;
+    sectionDiv.appendChild(heading);
+
+    section.items.forEach(item => {
+      const itemDiv = document.createElement('div');
+      itemDiv.className = 'mt-2';
+      itemDiv.innerHTML = `<p class="font-semibold">${item.role}</p>` +
+        `<p class="text-sm text-gray-600 dark:text-gray-400">${item.org} – ${item.period}</p>` +
+        `<p class="mt-1 text-sm">${item.details}</p>`;
+      sectionDiv.appendChild(itemDiv);
+    });
+    cvList.appendChild(sectionDiv);
+  });
+
+  const projectsList = document.getElementById('projectsList');
+  data.projects.forEach(p => {
+    const pDiv = document.createElement('div');
+    pDiv.innerHTML = `<a class="text-blue-600 dark:text-blue-400 underline font-medium" target="_blank" href="${p.link}">${p.title}</a>` +
+      `<p class="text-sm">${p.description}</p>`;
+    projectsList.appendChild(pDiv);
+  });
+
+  const skillsList = document.getElementById('skillsList');
+  data.skills.forEach(skill => {
+    const li = document.createElement('li');
+    li.textContent = skill;
+    skillsList.appendChild(li);
+  });
+
+  const contactList = document.getElementById('contactList');
+  Object.entries(data.contact).forEach(([key, value]) => {
+    const li = document.createElement('li');
+    const label = key.charAt(0).toUpperCase() + key.slice(1);
+    if (key === 'email') {
+      li.innerHTML = `<a href="mailto:${value}" class="underline">${value}</a>`;
+    } else {
+      li.innerHTML = `<a href="${value}" target="_blank" class="underline">${label}</a>`;
+    }
+    contactList.appendChild(li);
+  });
+}
+
+function initThemeToggle() {
+  const toggle = document.getElementById('themeToggle');
+  const root = document.documentElement;
+  const stored = localStorage.getItem('theme');
+  if (stored === 'dark') {
+    root.classList.add('dark');
+  }
+  toggle.addEventListener('click', () => {
+    root.classList.toggle('dark');
+    localStorage.setItem('theme', root.classList.contains('dark') ? 'dark' : 'light');
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initThemeToggle();
+  loadContent();
+});


### PR DESCRIPTION
## Summary
- replace the existing page with a Tailwind-powered layout that loads all CV sections from a JSON data file
- add a light/dark theme toggle persisted in localStorage
- document site structure, customization and GitHub Pages deployment steps in README

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894f0bdac988328a89c253bc279487f